### PR TITLE
Fixed IOS bug with starting camera

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -133,11 +133,13 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         };
                         frames = 0;
                         captureDevice = camDevices.First(d => d.UniqueID == cameraView.Camera.DeviceId);
+                        captureDevice.LockForConfiguration(out NSError err);
                         if (captureDevice.IsFocusModeSupported(AVCaptureFocusMode.ContinuousAutoFocus))
                             captureDevice.FocusMode = AVCaptureFocusMode.ContinuousAutoFocus;
                         else
                             captureDevice.FocusMode = AVCaptureFocusMode.AutoFocus;
-                        captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
+                        captureDevice.UnlockForConfiguration();
+                        captureInput = new AVCaptureDeviceInput(captureDevice, out err);
                         captureSession.AddInput(captureInput);
                         micDevice = micDevices.First(d => d.UniqueID == cameraView.Microphone.DeviceId);
                         micInput = new AVCaptureDeviceInput(micDevice, out err);
@@ -199,11 +201,13 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         };
                         frames = 0;
                         captureDevice = camDevices.First(d => d.UniqueID == cameraView.Camera.DeviceId);
+                        captureDevice.LockForConfiguration(out NSError err);
                         if (captureDevice.IsFocusModeSupported(AVCaptureFocusMode.ContinuousAutoFocus))
                             captureDevice.FocusMode = AVCaptureFocusMode.ContinuousAutoFocus;
                         else
                             captureDevice.FocusMode = AVCaptureFocusMode.AutoFocus;
-                        captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
+                        captureDevice.UnlockForConfiguration();
+                        captureInput = new AVCaptureDeviceInput(captureDevice, out err);
                         captureSession.AddInput(captureInput);
                         captureSession.AddOutput(videoDataOutput);
                         captureSession.AddOutput(photoOutput);


### PR DESCRIPTION
Found an issue with starting the camera on IOS, tracked it down to the focus mode being set without the device being locked for configuration, was throwing an error and not starting the camera. 

Just added calls to **LockForConfiguration()** and **UnlockForConfiguration()** as required on **StartRecordingAsync()** and **StartCameraAsync()**.