### PR TITLE
Provide Observer object for RemoveObserver

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -37,6 +37,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
     private bool photoTaken = false;
     private bool photoError = false;
     private UIImage photo;
+    private NSObject orientationObserver;
 
     public MauiCameraView(CameraView cameraView)
     {
@@ -61,7 +62,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
         cameraDispacher = new DispatchQueue("CameraDispacher");
 
         videoDataOutput.SetSampleBufferDelegate(this, cameraDispacher);
-        NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, OrientationChanged);
+        orientationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification, OrientationChanged);
         InitDevices();
     }
     private void OrientationChanged(NSNotification notification)
@@ -260,7 +261,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
     public void DisposeControl()
     {
         if (started) StopCamera();
-        NSNotificationCenter.DefaultCenter.RemoveObserver(UIDevice.OrientationDidChangeNotification);
+        NSNotificationCenter.DefaultCenter.RemoveObserver(orientationObserver);
         PreviewLayer?.Dispose();
         captureSession?.Dispose();
         Dispose();


### PR DESCRIPTION
I was observing System.ObjectDisposedException for already closed instances of the CameraView whenever I changed my iOS device's orientation.
I could trace it back to the OrientationChanged observer that is not correctly removed on dispose.
The call to RemoveObserver() should have the return value of AddObserver() as its first parameter.