### PR TITLE
Set CameraInfo.HorizontalViewAngle on iOS/Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 
 # Mono auto generated files
 mono_crash.*
+.mono
+
+.DS_Store
 
 # Build results
 [Dd]ebug/

--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -93,6 +93,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         HasFlashUnit = device.FlashAvailable,
                         MinZoomFactor = (float)device.MinAvailableVideoZoomFactor,
                         MaxZoomFactor = (float)device.MaxAvailableVideoZoomFactor,
+                        HorizontalViewAngle = device.ActiveFormat.VideoFieldOfView * MathF.PI / 180,
                         AvailableResolutions = new() { new(1920, 1080), new(1280, 720), new(640, 480), new(352, 288) }
                     });
                 }


### PR DESCRIPTION
... using this property:

https://developer.apple.com/documentation/avfoundation/avcapturedeviceformat/1624569-videofieldofview

From the documentation:

> Indicates the format’s horizontal field of view in degrees.

So we have to convert it from degrees to radians.

Fixes issue #120 (at least partially).