### PR TITLE
Additional camera options on iOS and some bug-fixes

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -75,7 +75,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
         {
             try
             {
-                var deviceDescoverySession = AVCaptureDeviceDiscoverySession.Create(new AVCaptureDeviceType[] { AVCaptureDeviceType.BuiltInWideAngleCamera }, AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
+                var deviceDescoverySession = AVCaptureDeviceDiscoverySession.Create(new AVCaptureDeviceType[] { AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.BuiltInUltraWideCamera, AVCaptureDeviceType.BuiltInDualWideCamera, AVCaptureDeviceType.BuiltInTripleCamera, AVCaptureDeviceType.BuiltInTelephotoCamera }, AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
                 camDevices = deviceDescoverySession.Devices;
                 cameraView.Cameras.Clear();
                 foreach (var device in camDevices)
@@ -573,7 +573,6 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
         }
 
         NSData imageData = AVCapturePhotoOutput.GetJpegPhotoDataRepresentation(photoSampleBuffer, previewPhotoSampleBuffer);
-
         photo = new UIImage(imageData);
         photoTaken = true;
     }

--- a/Camera.MAUI/BarcodeImage.xaml
+++ b/Camera.MAUI/BarcodeImage.xaml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Camera.MAUI.BarcodeImage" x:Name="barcodeImage">
+             xmlns:local="clr-namespace:Camera.MAUI"
+             x:Class="Camera.MAUI.BarcodeImage" x:Name="barcodeImage"
+             x:DataType="local:BarcodeImage">
     <Grid>
         <Image x:Name="image" BindingContext="{x:Reference barcodeImage}" HorizontalOptions="Fill" VerticalOptions="Fill" Aspect="{Binding Aspect}"/>
     </Grid>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -29,21 +29,16 @@
 		<Authors>hjam40</Authors>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Version>1.5</Version>
-		<PackageReleaseNotes>Split barcode encoder/decoder in a different package. Fix some bugs
-</PackageReleaseNotes>
-		<PackageLicenseFile>license.md</PackageLicenseFile>
+		<PackageReleaseNotes>Split barcode encoder/decoder in a different package. Fix some bugs</PackageReleaseNotes>
+		<PackageLicenseFile>LICENSE.md</PackageLicenseFile>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0-ios'">
 	  <ProvisioningType>manual</ProvisioningType>
 	</PropertyGroup>
-
+	
 	<ItemGroup>
-	  <None Remove="license.md" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <EmbeddedResource Include="license.md">
+	  <EmbeddedResource Include="../LICENSE.md">
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </EmbeddedResource>


### PR DESCRIPTION
Hi

- Fixed build problem after rename and move of license.md to ../LICENSE.md
- Added x:DataType on BarcodeImage.xaml to allow for compiled xaml bindings
- Added iOS camera search pattern to allow for more camera options

The is needed for myself to enable better focused close-ups when taking pictures with text

Regards
René